### PR TITLE
Half-solution of issue #2

### DIFF
--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -97,6 +97,8 @@ parseSlice first firstClose trimmed =
             [] ->
                 if String.startsWith "?" tagName then
                     Ok ( DocType tagName props, firstClose + 1 )
+                else if (List.reverse words |> List.head |> Maybe.withDefault "") == "/" then
+                    Ok ( Tag tagName props (Object []), firstClose )
                 else
                     "Failed to find close tag for "
                         ++ tagName


### PR DESCRIPTION
It solves issue #2, but only when using a single tag. For instance, now you can use:

```
<tag>
    <autoclosing />
</tag>
```

but you can't

```
<tag>
    <autoclosing />
    <autoclosing />
</tag>
```

As the code is not well comented, I didn't manage to solve the whole problem. Fighting with it.