### PR TITLE
Self closing tags does not require spaces before />

### DIFF
--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -120,19 +120,18 @@ parseSlice first firstClose trimmed =
 actualDecode : String -> Result String (List Value)
 actualDecode text =
     let
-        txt = String.trim text
         openIndexes =
-            String.indexes "<" txt
+            String.indexes "<" text
 
         closeIndexes =
-            String.indexes ">" txt
+            String.indexes ">" text
     in
         case ( openIndexes, closeIndexes ) of
             ( first :: restFirst, firstClose :: restFirstClose ) ->
-                parseSlice first firstClose txt
+                parseSlice first firstClose text
                     |> Result.andThen
                         (\( foundValue, firstCloseTag ) ->
-                            case actualDecode (String.slice firstCloseTag (String.length txt + 1) txt) of
+                            case actualDecode (String.slice firstCloseTag (String.length text + 1) text) of
                                 Err err ->
                                     if err == "Nothing left" then
                                         Ok [ foundValue ]

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -97,7 +97,7 @@ parseSlice first firstClose trimmed =
             [] ->
                 if String.startsWith "?" tagName then
                     Ok ( DocType tagName props, firstClose + 1 )
-                else if (String.endsWith "/>" trimmed) then
+                else if (String.contains "/>" trimmed) then
                     Ok ( Tag tagName props (Object []), firstClose + 1 )
                 else
                     "Failed to find close tag for "
@@ -120,18 +120,19 @@ parseSlice first firstClose trimmed =
 actualDecode : String -> Result String (List Value)
 actualDecode text =
     let
+        txt = String.trim text
         openIndexes =
-            String.indexes "<" text
+            String.indexes "<" txt
 
         closeIndexes =
-            String.indexes ">" text
+            String.indexes ">" txt
     in
         case ( openIndexes, closeIndexes ) of
             ( first :: restFirst, firstClose :: restFirstClose ) ->
-                parseSlice first firstClose text
+                parseSlice first firstClose txt
                     |> Result.andThen
                         (\( foundValue, firstCloseTag ) ->
-                            case actualDecode (String.slice firstCloseTag (String.length text + 1) text) of
+                            case actualDecode (String.slice firstCloseTag (String.length txt + 1) txt) of
                                 Err err ->
                                     if err == "Nothing left" then
                                         Ok [ foundValue ]

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -97,7 +97,7 @@ parseSlice first firstClose trimmed =
             [] ->
                 if String.startsWith "?" tagName then
                     Ok ( DocType tagName props, firstClose + 1 )
-                else if (List.reverse words |> List.head |> Maybe.withDefault "") == "/" then
+                else if (String.endsWith "/>" trimmed) then
                     Ok ( Tag tagName props (Object []), firstClose + 1 )
                 else
                     "Failed to find close tag for "

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -18,6 +18,7 @@ example =
         , ( "age", Dict.empty, int 5 )
         ]
 
+
 exampleAsString : String
 exampleAsString =
     """
@@ -26,28 +27,33 @@ exampleAsString =
 """
         |> String.trim
 
+
 selfClosingExampleAsString : String
 selfClosingExampleAsString =
-  """
+    """
 <person>
     <name is="me">kitofr</name>
     <here is="false" />
-    <here is="true" />
+    <here is="true"/>
+    <name is="me">kitofr</name>
 </person>
 """
 
+
 selfClosingExample : Value
 selfClosingExample =
-  object [
-    ( "person"
+    object
+        [ ( "person"
           , Dict.empty
           , object
                 [ ( "name", Dict.fromList [ ( "is", string "me" ) ], string "kitofr" )
                 , ( "here", Dict.fromList [ ( "is", bool False ) ], null )
                 , ( "here", Dict.fromList [ ( "is", bool True ) ], null )
+                , ( "name", Dict.fromList [ ( "is", string "me" ) ], string "kitofr" )
                 ]
           )
-    ]
+        ]
+
 
 exampleWithProps : Value
 exampleWithProps =


### PR DESCRIPTION
@eeue56 that seemed to be a better, and more robust (!?) option than the latter. Apparently it's not valid for xml to end self closing tags in any other way. 

I think it's safe to call `contains` with `/>` because we didn't find any closing tag for this one. Might however be neater to do something else... like check that `/` is the first char behind the found closing one etc. but that's probably a matter of taste.