### PR TITLE
Xml/Encode: ensure closing tags are properly indented

### DIFF
--- a/src/Xml/Encode.elm
+++ b/src/Xml/Encode.elm
@@ -68,19 +68,31 @@ valueToString level indent value =
     case value of
         Tag name props nextValue ->
             let
-                indentString =
-                    if needsIndent nextValue then
+                indentation =
+                    String.repeat (indent * level // 2) " "
+
+                newlineNecessary =
+                    needsIndent nextValue
+
+                maybeNewline =
+                    if newlineNecessary then
                         "\n"
                     else
                         ""
             in
-                "<"
+                indentation
+                    ++ "<"
                     ++ name
                     ++ (propsToString props)
                     ++ ">"
-                    ++ indentString
+                    ++ maybeNewline
                     ++ (valueToString (level + 1) indent nextValue)
-                    ++ indentString
+                    ++ maybeNewline
+                    ++ (if newlineNecessary then
+                            indentation
+                        else
+                            ""
+                       )
                     ++ "</"
                     ++ name
                     ++ ">"
@@ -99,7 +111,6 @@ valueToString level indent value =
 
         Object xs ->
             List.map (valueToString (level + 1) indent) xs
-                |> List.map ((++) (String.repeat (level * indent) " "))
                 |> String.join "\n"
 
         DocType name props ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -135,6 +135,41 @@ decodedExampleStuff =
     decode ExampleStuff.stuff
 
 
+threeLayersAsString : String
+threeLayersAsString =
+    """
+<person>
+<name>
+  <firstname>Chris</firstname>
+  <lastname>topher</lastname>
+  <meta>
+    <suffix>Jr</suffix>
+  </meta>
+</name>
+</person>
+"""
+        |> String.trim
+
+
+threeLayers : Value
+threeLayers =
+    Tag "person" Dict.empty <|
+        Tag "name" Dict.empty <|
+            list
+                [ Tag "firstname" Dict.empty <| StrNode "Chris"
+                , Tag "lastname" Dict.empty <| StrNode "topher"
+                , Tag "meta" Dict.empty <|
+                    list
+                        [ Tag "suffix" Dict.empty <| StrNode "Jr"
+                        ]
+                ]
+
+
+encodedThreeLayers : String
+encodedThreeLayers =
+    encode 2 threeLayers
+
+
 all : Test
 all =
     describe "Encode test"
@@ -209,4 +244,7 @@ all =
                 Expect.equal
                     (List.length <| Result.withDefault [] <| ExampleStuff.fromXML <| ExampleStuff.stuff)
                     100
+        , test "three layers of tags are properly indented" <|
+            \_ ->
+                Expect.equal encodedThreeLayers threeLayersAsString
         ]


### PR DESCRIPTION
- [x] Ensure closing tags are properly indented.
- [x] Include a unit test over this behavior.
- [x] All tests passing.

Before
```
<person>
<name>
  <firstname>Chris</firstname>
  <lastname>topher</lastname>
  <meta>
      <suffix>Jr</suffix>
</meta>
</name>
</person>
```

After this change

```
<person>
<name>
  <firstname>Chris</firstname>
  <lastname>topher</lastname>
  <meta>
    <suffix>Jr</suffix>
  </meta>
</name>
</person>
```

Note the indentation of the closing `</meta>` tag.