### PR TITLE
Fix missing imports in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ In order to turn an `Xml.Value` into a record, you probably want `Xml.Query`, pa
 import Xml exposing (Value)
 import Xml.Encode exposing (null)
 import Xml.Decode exposing (decode)
-import Xml.Query exposing (tags)
+import Xml.Query exposing (collect, int, string, tag, tags)
 
 decodedXml : Value
-decodedXml = 
+decodedXml =
 	"""
 <person>
 	<name>noah</name>
@@ -31,7 +31,7 @@ decodedXml =
 		|> Maybe.withDefault null
 
 
-type alias Person = 
+type alias Person =
 	{ name: String
 	, age: Int
 	}

--- a/src/Xml.elm
+++ b/src/Xml.elm
@@ -1,12 +1,11 @@
 module Xml exposing (Value(..), map, foldl, xmlToJson, jsonToXml)
 
-{-|
-
-The main data structure along with some trivial helpers.
+{-| The main data structure along with some trivial helpers.
 
 @docs Value
 
 @docs foldl, map, xmlToJson, jsonToXml
+
 -}
 
 import Dict exposing (Dict)
@@ -27,6 +26,7 @@ type Value
 
 
 {-|
+
     Standard mapping of a value to another value
 -}
 map : (Value -> Value) -> Value -> Value
@@ -83,6 +83,7 @@ foldl fn init value =
 
     xmlToJson (DocType "" Dict.empty)
     --> Json.null
+
 -}
 xmlToJson : Value -> Json.Value
 xmlToJson xml =
@@ -134,6 +135,9 @@ xmlDecoder =
 
 
 {-| Convert a `Json.Value` into an `Xml.Value`
+
+    import Dict
+    import Json.Encode as Json
 
     jsonToXml (Json.string "hello")
     --> StrNode "hello"

--- a/src/Xml/Decode.elm
+++ b/src/Xml/Decode.elm
@@ -1,12 +1,11 @@
 module Xml.Decode exposing (decode, decodeInt, decodeString, decodeFloat, decodeBool, decodeChildren)
 
-{-|
-
-@docs decode
+{-| @docs decode
 
 @docs decodeInt, decodeFloat, decodeString, decodeString, decodeBool
 
 @docs decodeChildren
+
 -}
 
 import Dict
@@ -99,10 +98,11 @@ parseSlice first firstClose trimmed =
                     Ok ( DocType tagName props, firstClose + 1 )
                 else if String.endsWith "/" beforeClose then
                     let
-                        tag = if String.endsWith "/" tagName then
-                                  String.slice 0 -1 tagName
-                              else
-                                  tagName
+                        tag =
+                            if String.endsWith "/" tagName then
+                                String.slice 0 -1 tagName
+                            else
+                                tagName
                     in
                         Ok ( Tag tag props (Object []), firstClose + 1 )
                 else
@@ -155,12 +155,14 @@ actualDecode text =
 
 
 {-| Try to decode a string and turn it into an XML value
+
+    import Dict
     import Xml exposing(Value(Tag, Object))
     import Xml.Encode exposing (null)
-    import Dict
 
     decode "<name></name>"
     --> Ok (Object [Tag "name" Dict.empty null])
+
 -}
 decode : String -> Result String Value
 decode text =
@@ -179,6 +181,7 @@ decode text =
 
     decodeString "hello"
     --> Ok (StrNode "hello")
+
 -}
 decodeString : String -> Result String Value
 decodeString str =
@@ -187,6 +190,7 @@ decodeString str =
 
 
 {-| Decode a int
+
     import Xml exposing (Value(IntNode))
 
     decodeInt "hello"
@@ -194,6 +198,7 @@ decodeString str =
 
     decodeInt "5"
     --> Ok (IntNode 5)
+
 -}
 decodeInt : String -> Result String Value
 decodeInt str =
@@ -207,6 +212,7 @@ decodeInt str =
 
 
 {-| Decode a float
+
     import Xml exposing (Value(FloatNode))
 
     decodeFloat "hello"
@@ -246,6 +252,7 @@ decodeBool str =
 
 {-| Decode children from a string
 
+    import Dict
     import Xml exposing (Value(Object, Tag, StrNode))
 
     decodeChildren "<name>hello</name>"

--- a/src/Xml/Query.elm
+++ b/src/Xml/Query.elm
@@ -2,6 +2,7 @@ module Xml.Query exposing (tags, contains, tag, collect, string, int, float, boo
 
 {-|
 
+
 # Search the parsed XML
 
 @docs tags, contains
@@ -9,14 +10,16 @@ module Xml.Query exposing (tags, contains, tag, collect, string, int, float, boo
 @docs tag, collect, default
 
 @docs string, int, float, bool
+
 -}
 
 import Xml exposing (Value(..))
 
 
 {-| Try to get a given tag name out from an XML value, then grab the value from that
-    Grabs the first tag that matches in the object
+Grabs the first tag that matches in the object
 
+    import Dict
     import Xml exposing (Value(..))
 
     tag "name" string (Tag "name" Dict.empty (StrNode "noah"))
@@ -27,6 +30,7 @@ import Xml exposing (Value(..))
 
     tag "name" string (StrNode "noah")
     --> Err "No tag called 'name' found."
+
 -}
 tag : String -> (Value -> Result String a) -> Value -> Result String a
 tag name converter value =
@@ -51,11 +55,16 @@ tag name converter value =
 
 {-| Collect as many values that pass the given converter
 
+    import Dict
+    import Xml exposing (Value(IntNode, StrNode, Tag))
+    import Xml.Query exposing (collect, string, tag)
+
     collect (tag "name" string) [Tag "name" Dict.empty (StrNode "noah")]
     --> [ "noah" ]
 
     collect (tag "name" string) [Tag "name" Dict.empty (IntNode 5)]
     --> [ ]
+
 -}
 collect : (Value -> Result String a) -> List Value -> List a
 collect fn values =
@@ -64,11 +73,14 @@ collect fn values =
 
 {-| Try to turn a value into a string
 
+    import Xml exposing (Value(IntNode, StrNode))
+
     string (IntNode 5)
     --> Err "Not a string."
 
     string (StrNode "hello")
     --> Ok "hello"
+
 -}
 string : Value -> Result String String
 string value =
@@ -82,11 +94,14 @@ string value =
 
 {-| Try to turn a value into an int
 
+    import Xml exposing (Value(IntNode, StrNode))
+
     int (IntNode 5)
     --> Ok 5
 
     int (StrNode "hello")
     --> Err "Not an int"
+
 -}
 int : Value -> Result String Int
 int value =
@@ -100,11 +115,14 @@ int value =
 
 {-| Try to turn a value into an int
 
+    import Xml exposing (Value(FloatNode, StrNode))
+
     float (FloatNode 5.5)
     --> Ok 5.5
 
     float (StrNode "hello")
     --> Err "Not a float"
+
 -}
 float : Value -> Result String Float
 float value =
@@ -118,11 +136,14 @@ float value =
 
 {-| Try to turn a value into an int
 
+    import Xml exposing (Value(BoolNode, StrNode))
+
     bool (BoolNode True)
     --> Ok True
 
     bool (StrNode "hello")
     --> Err "Not a bool"
+
 -}
 bool : Value -> Result String Bool
 bool value =
@@ -135,6 +156,7 @@ bool value =
 
 
 {-|
+
     Set a default for a result
 
     >> default "Cat" (Ok "Fish")


### PR DESCRIPTION
This PR fixes the missing imports that were causing elm-verify-examples to fail. It also fixes the missing imports in the example in the README—it compiles now.

Issues affected:
- This PR closes #12
- This PR closes #14 